### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/frpc.yml
+++ b/.github/workflows/frpc.yml
@@ -33,7 +33,7 @@ jobs:
           # https://github.com/docker/buildx/issues/136#issuecomment-550205439
           # docker buildx create --driver-opt env.http_proxy=$http_proxy --driver-opt env.https_proxy=$https_proxy --driver-opt '"env.no_proxy='$no_proxy'"'
           name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3.6.0
+          uses: docker/setup-buildx-action@v3.6.1
           with:
             buildkitd-config: .github/buildkitd.toml
             driver-opts: |

--- a/.github/workflows/frps.yml
+++ b/.github/workflows/frps.yml
@@ -33,7 +33,7 @@ jobs:
           # https://github.com/docker/buildx/issues/136#issuecomment-550205439
           # docker buildx create --driver-opt env.http_proxy=$http_proxy --driver-opt env.https_proxy=$https_proxy --driver-opt '"env.no_proxy='$no_proxy'"'
           name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3.6.0
+          uses: docker/setup-buildx-action@v3.6.1
           with:
             buildkitd-config: .github/buildkitd.toml
             driver-opts: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.6.1](https://github.com/docker/setup-buildx-action/releases/tag/v3.6.1)** on 2024-07-29T16:31:19Z
