### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/frpc.yml
+++ b/.github/workflows/frpc.yml
@@ -55,7 +55,7 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}          
         -
           name: Build and push
-          uses: docker/build-push-action@v6.5.0
+          uses: docker/build-push-action@v6.6.1
           with:
             context: frpc
             platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/riscv64,linux/s390x

--- a/.github/workflows/frps.yml
+++ b/.github/workflows/frps.yml
@@ -55,7 +55,7 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}          
         -
           name: Build and push
-          uses: docker/build-push-action@v6.5.0
+          uses: docker/build-push-action@v6.6.1
           with:
             context: frps
             platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/riscv64,linux/s390x


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.6.1](https://github.com/docker/build-push-action/releases/tag/v6.6.1)** on 2024-08-07T20:19:19Z
