### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/alpine-frpc.yml
+++ b/.github/workflows/alpine-frpc.yml
@@ -63,18 +63,21 @@ jobs:
             prefix=
             suffix=
           tags: |
+            type=ref,enable=true,priority=600,prefix=,suffix=,event=branch
             type=edge,enable=true,priority=700,prefix=,suffix=,branch=dev
             type=raw,enable={{is_default_branch}},priority=200,prefix=,suffix=,value=latest
             type=raw,enable=${{ startsWith(github.ref, 'refs/tags/') }},priority=200,prefix=,suffix=,value=latest
             type=pep440,enable=true,priority=900,prefix=,suffix=,pattern={{version}}
             type=pep440,enable=true,priority=900,prefix=,suffix=,pattern={{major}}.{{minor}}
             type=pep440,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') && !startsWith(github.ref, 'refs/tags/0.') }},priority=900,prefix=,suffix=,pattern={{major}}
+            type=ref,enable=true,priority=600,prefix=,suffix=-alpine,event=branch
             type=edge,enable=true,priority=700,prefix=,suffix=-alpine,branch=dev
             type=raw,enable={{is_default_branch}},priority=200,prefix=,suffix=,value=alpine
             type=raw,enable=${{ startsWith(github.ref, 'refs/tags/') }},priority=200,prefix=,suffix=,value=alpine
             type=pep440,enable=true,priority=900,prefix=,suffix=-alpine,pattern={{version}}
             type=pep440,enable=true,priority=900,prefix=,suffix=-alpine,pattern={{major}}.{{minor}}
             type=pep440,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') && !startsWith(github.ref, 'refs/tags/0.') }},priority=900,prefix=,suffix=-alpine,pattern={{major}}
+            type=ref,enable=true,priority=600,prefix=,suffix=-alpine3.20,event=branch
             type=edge,enable=true,priority=700,prefix=,suffix=-alpine3.20,branch=dev
             type=raw,enable={{is_default_branch}},priority=200,prefix=,suffix=,value=alpine3.20
             type=raw,enable=${{ startsWith(github.ref, 'refs/tags/') }},priority=200,prefix=,suffix=,value=alpine3.20

--- a/.github/workflows/alpine-frpc.yml
+++ b/.github/workflows/alpine-frpc.yml
@@ -87,7 +87,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.8.0
+        uses: docker/build-push-action@v6.9.0
         with:
           context: alpine/frpc
           build-args: |

--- a/.github/workflows/alpine-frps.yml
+++ b/.github/workflows/alpine-frps.yml
@@ -63,18 +63,21 @@ jobs:
             prefix=
             suffix=
           tags: |
+            type=ref,enable=true,priority=600,prefix=,suffix=,event=branch
             type=edge,enable=true,priority=700,prefix=,suffix=,branch=dev
             type=raw,enable={{is_default_branch}},priority=200,prefix=,suffix=,value=latest
             type=raw,enable=${{ startsWith(github.ref, 'refs/tags/') }},priority=200,prefix=,suffix=,value=latest
             type=pep440,enable=true,priority=900,prefix=,suffix=,pattern={{version}}
             type=pep440,enable=true,priority=900,prefix=,suffix=,pattern={{major}}.{{minor}}
             type=pep440,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') && !startsWith(github.ref, 'refs/tags/0.') }},priority=900,prefix=,suffix=,pattern={{major}}
+            type=ref,enable=true,priority=600,prefix=,suffix=-alpine,event=branch
             type=edge,enable=true,priority=700,prefix=,suffix=-alpine,branch=dev
             type=raw,enable={{is_default_branch}},priority=200,prefix=,suffix=,value=alpine
             type=raw,enable=${{ startsWith(github.ref, 'refs/tags/') }},priority=200,prefix=,suffix=,value=alpine
             type=pep440,enable=true,priority=900,prefix=,suffix=-alpine,pattern={{version}}
             type=pep440,enable=true,priority=900,prefix=,suffix=-alpine,pattern={{major}}.{{minor}}
             type=pep440,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') && !startsWith(github.ref, 'refs/tags/0.') }},priority=900,prefix=,suffix=-alpine,pattern={{major}}
+            type=ref,enable=true,priority=600,prefix=,suffix=-alpine3.20,event=branch
             type=edge,enable=true,priority=700,prefix=,suffix=-alpine3.20,branch=dev
             type=raw,enable={{is_default_branch}},priority=200,prefix=,suffix=,value=alpine3.20
             type=raw,enable=${{ startsWith(github.ref, 'refs/tags/') }},priority=200,prefix=,suffix=,value=alpine3.20

--- a/.github/workflows/alpine-frps.yml
+++ b/.github/workflows/alpine-frps.yml
@@ -87,7 +87,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.8.0
+        uses: docker/build-push-action@v6.9.0
         with:
           context: alpine/frps
           build-args: |

--- a/.github/workflows/debian-frpc.yml
+++ b/.github/workflows/debian-frpc.yml
@@ -80,7 +80,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.8.0
+        uses: docker/build-push-action@v6.9.0
         with:
           context: debian/frpc
           build-args: |

--- a/.github/workflows/debian-frpc.yml
+++ b/.github/workflows/debian-frpc.yml
@@ -63,12 +63,14 @@ jobs:
             prefix=
             suffix=
           tags: |
-           type=edge,enable=true,priority=700,prefix=,suffix=-debian,branch=dev
+            type=ref,enable=true,priority=600,prefix=,suffix=-debian,event=branch
+            type=edge,enable=true,priority=700,prefix=,suffix=-debian,branch=dev
             type=raw,enable={{is_default_branch}},priority=200,prefix=,suffix=,value=debian
             type=raw,enable=${{ startsWith(github.ref, 'refs/tags/') }},priority=200,prefix=,suffix=,value=debian
             type=pep440,enable=true,priority=900,prefix=,suffix=-debian,pattern={{version}}
             type=pep440,enable=true,priority=900,prefix=,suffix=-debian,pattern={{major}}.{{minor}}
             type=pep440,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') && !startsWith(github.ref, 'refs/tags/0.') }},priority=900,prefix=,suffix=-debian,pattern={{major}}
+            type=ref,enable=true,priority=600,prefix=,suffix=-bookworm,event=branch
             type=edge,enable=true,priority=700,prefix=,suffix=-bookworm,branch=dev
             type=raw,enable={{is_default_branch}},priority=200,prefix=,suffix=,value=bookworm
             type=raw,enable=${{ startsWith(github.ref, 'refs/tags/') }},priority=200,prefix=,suffix=,value=bookworm

--- a/.github/workflows/debian-frps.yml
+++ b/.github/workflows/debian-frps.yml
@@ -80,7 +80,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.8.0
+        uses: docker/build-push-action@v6.9.0
         with:
           context: debian/frps
           build-args: |

--- a/.github/workflows/debian-frps.yml
+++ b/.github/workflows/debian-frps.yml
@@ -63,12 +63,14 @@ jobs:
             prefix=
             suffix=
           tags: |
+            type=ref,enable=true,priority=600,prefix=,suffix=-debian,event=branch
             type=edge,enable=true,priority=700,prefix=,suffix=-debian,branch=dev
             type=raw,enable={{is_default_branch}},priority=200,prefix=,suffix=,value=debian
             type=raw,enable=${{ startsWith(github.ref, 'refs/tags/') }},priority=200,prefix=,suffix=,value=debian
             type=pep440,enable=true,priority=900,prefix=,suffix=-debian,pattern={{version}}
             type=pep440,enable=true,priority=900,prefix=,suffix=-debian,pattern={{major}}.{{minor}}
             type=pep440,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') && !startsWith(github.ref, 'refs/tags/0.') }},priority=900,prefix=,suffix=-debian,pattern={{major}}
+            type=ref,enable=true,priority=600,prefix=,suffix=-bookworm,event=branch
             type=edge,enable=true,priority=700,prefix=,suffix=-bookworm,branch=dev
             type=raw,enable={{is_default_branch}},priority=200,prefix=,suffix=,value=bookworm
             type=raw,enable=${{ startsWith(github.ref, 'refs/tags/') }},priority=200,prefix=,suffix=,value=bookworm


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.9.0](https://github.com/docker/build-push-action/releases/tag/v6.9.0)** on 2024-09-30T09:51:48Z
