### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/alpine-frpc.yml
+++ b/.github/workflows/alpine-frpc.yml
@@ -144,7 +144,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.17.0
+        uses: docker/build-push-action@v6.18.0
         with:
           context: alpine/frpc
           build-args: |

--- a/.github/workflows/alpine-frps.yml
+++ b/.github/workflows/alpine-frps.yml
@@ -144,7 +144,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.17.0
+        uses: docker/build-push-action@v6.18.0
         with:
           context: alpine/frps
           build-args: |

--- a/.github/workflows/debian-frpc.yml
+++ b/.github/workflows/debian-frpc.yml
@@ -136,7 +136,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.17.0
+        uses: docker/build-push-action@v6.18.0
         with:
           context: debian/frpc
           build-args: |

--- a/.github/workflows/debian-frps.yml
+++ b/.github/workflows/debian-frps.yml
@@ -136,7 +136,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.17.0
+        uses: docker/build-push-action@v6.18.0
         with:
           context: debian/frps
           build-args: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.18.0](https://github.com/docker/build-push-action/releases/tag/v6.18.0)** on 2025-05-27T16:39:16Z
